### PR TITLE
fix slow bmi calculation bug

### DIFF
--- a/src/pages/Food.js
+++ b/src/pages/Food.js
@@ -1,7 +1,7 @@
-import {useState} from 'react';
-import { getRecipeData, searchRecipes, customRecipesByBMI, resetCustomRecipesByBMI } from '../recipeFunctions';
+import {useState, useEffect} from 'react';
+import { getRecipeData, searchRecipes, getCustomThresholds } from '../recipeFunctions';
 import { useUser } from '../firebaseFunctions';
-
+import { getUserField } from '../userFunctions';
 
 
 function DisplayOneRecipe({recipeName}){
@@ -103,6 +103,23 @@ function Food() {
   });
   const [recipes, setRecipes] = useState([]);
   const user = useUser();
+  const [weight, setWeight] = useState("");
+  const [height, setHeight] = useState("");
+
+  useEffect(() => {
+    if (user) {
+      getUserField(user, "weight").then((weight) => {
+        if (weight && weight > 0) {
+          setWeight(weight);
+        }
+      });
+      getUserField(user, "height").then((height) => {
+        if (height) {
+          setHeight(height);
+        }
+      });
+    }
+  }, [user]);
 
   function MyForm() {
     const handleCheckboxChange = (event) => {
@@ -116,15 +133,10 @@ function Food() {
     const handleSubmit = async (event) => {
       event.preventDefault();
 
-      resetCustomRecipesByBMI();
-      if(user && checkboxValues.custom){
-
-        await customRecipesByBMI(user);
-      }
       setRecipes([]);
       // Handle form submission or perform any desired actions with checkboxValues
       const options = Object.values(checkboxValues);
-      searchRecipes(...options).then((recipes) => {
+      searchRecipes(...options, height, weight).then((recipes) => {
         if (recipes) {
           setRecipes(recipes);
         }

--- a/src/userFunctions.js
+++ b/src/userFunctions.js
@@ -28,29 +28,3 @@ export async function getUserField(user, field) {
         console.error(error.message);
     }
 };
-
-export function calculateBMI(heightInInches, weightInPounds) {
-
-// Convert height to meters
-    const heightInMeters = heightInInches * 0.0254;
-
-// Convert weight to kilograms
-    const weightInKilograms = weightInPounds * 0.45359237;
-
-// Calculate BMI
-    const bmi = weightInKilograms / (heightInMeters * heightInMeters);
-
-// Return BMI rounded to two decimal places
-    return bmi.toFixed(2); 
-  }
-
-export async function calculateUserBMI(user) {
-  const height = await getUserField(user, 'height');
-  const weight = await getUserField(user, 'weight');
-
-  if (height && weight) {
-    const bmi = calculateBMI(height, weight);
-    return bmi;
-  }
-
-}


### PR DESCRIPTION
The previous bmi algorithm had several nested async functions and re queried the user field objects every single time a search would be performed so it was extremely slow. The new algorithm retrieves the user's height and weight once and caches the values in local variables. The algorithm was completely redone and simplified to fewer functions and no longer uses async functions.